### PR TITLE
Negative Number Extension

### DIFF
--- a/lib/ext/jiff-client-negativenumber.js
+++ b/lib/ext/jiff-client-negativenumber.js
@@ -118,10 +118,8 @@
         }
         // o is negative
         else {
-          // correct for o
-          result = result.cmult(-1);
-          // if share is negative, result becomes positive again
-          result = result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
+          // if share is negative, result remains positive, otherwise it becomes negative
+          result = result.smult(selfNegative.cmult(2).cadd(-1), op_id+":cor1");
         }
 
         // Round to zero
@@ -130,7 +128,7 @@
         }
         // Round down
         else {
-          var need_round = result.smult(share, op_id+":floor:smult").cneq(cst, op_id+":floor:cneq");
+          var need_round = result.cmult(cst).sneq(share, op_id+":floor:cneq");
           var xorNegative = selfNegative.cxor_bit(otherNegative ? 1 : 0);
           return result.sadd(need_round.smult(xorNegative, op_id+":floor:&").cmult(-1));
         }
@@ -151,25 +149,21 @@
         // This is the result assuming both share and o are non-negative
         var result = shareAbs.legacy.sdiv(otherAbs, l, op_id+":/").cadd(offset);
 
+        // Correct if either share or o are negative but not both.
+        var xorNegative = selfNegative.sxor_bit(otherNegative);
+
         // correct for self
-        result = result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
-        // correct for o
-        result = result.smult(otherNegative.cmult(-2).cadd(1), op_id+":cor2");
-        // correct for both
-        var bothNegative = selfNegative.smult(otherNegative, op_id+":&");
-        //result = result.smult(bothNegative.cmult(-2).cadd(1), op_id+":cor3");
-        return result;
-        /*
+        result = result.smult(xorNegative.cmult(-2).cadd(1), op_id+":cor1");
+
         // Round to zero
         if(floor_down === false) {
           return result;
         }
         // Round down
         else {
-          var need_round = result.smult(share, op_id+":floor:smult").sneq(o, op_id+":floor:cneq");
-          var xorNegative = selfNegative.sadd(otherNegative).ssub(bothNegative.cmult(2));
-          return result.sadd(need_round.smult(xorNegative, op_id+":floor:&").cmult(-1));
-        }*/
+          var need_round = result.smult(o, op_id+":floor:smult").sneq(share, op_id+":floor:sgt");
+          return result.ssub(need_round.smult(xorNegative, op_id+":floor:&"));
+        }
       };
 
       // secret boolean operations

--- a/lib/ext/jiff-client-negativenumber.js
+++ b/lib/ext/jiff-client-negativenumber.js
@@ -20,7 +20,7 @@
     function createSecretShare(jiff, share, share_helpers) {
       // Keep a copy of the previous implementation of changed primitives
       share.legacy = {};
-      var internals = [ "cmult", "sadd", "ssub", "smult",
+      var internals = [ "cmult", "sadd", "ssub", "smult", "cdivfac", "cdiv", "sdiv",
                         "cxor_bit", "sxor_bit", "cor_bit", "sor_bit" ];
       for(var i = 0; i < internals.length; i++) {
         var key = internals[i];
@@ -47,15 +47,13 @@
       }
 
       // Secret arithmetic operations
-      var old_sadd = share.sadd;
       share.sadd = function(o) {
-        var result = old_sadd(o);
+        var result = share.legacy.sadd(o);
         return result.csub(offset);
       }
-      var old_sub = share.ssub;
       share.ssub = function(o) {
         // The offset will cancel with the normal ssub, so we add it back on
-        var result = old_sub(o);
+        var result = share.legacy.ssub(o);
         return result.cadd(offset);
       }
       share.smult = function(o, op_id) {
@@ -63,6 +61,115 @@
         o = o.csub(offset);
         result = result.legacy.smult(o, op_id);
         return result.cadd(offset);
+      };
+
+      // Divisions
+      share.cdivfac = function(cst, op_id) {
+        if (!(share.isConstant(cst))) {
+          throw 'Parameter should be a number (cdivfac)';
+        }
+
+        var shareAbs = share.abs(op_id, true);
+        var selfNegative = shareAbs.isNegative;
+        shareAbs = shareAbs.result.csub(offset);
+
+        var otherNegative = cst < 0;
+        cst = Math.abs(cst);
+
+        // This is the result assuming both share and o are non-negative
+        var result = shareAbs.legacy.cdivfac(cst).cadd(offset);
+        
+        // o is non-negative
+        if(!otherNegative) {
+          // only need to correct for if share is negative
+          return result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
+        }
+        // o is negative
+        else {
+          // correct for o
+          result = result.cmult(-1);
+          // if share is negative, result becomes positive again
+          return result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
+        }
+      };
+      share.cdiv = function(cst, op_id, floor_down) {
+        if (!(share.isConstant(cst))) {
+          throw 'Parameter should be a number (cdiv)';
+        }        
+
+        if (op_id == null) {
+          op_id = share.jiff.counters.gen_op_id('c/', share.holders);
+        }
+
+        var shareAbs = share.abs(op_id+":abs", true);
+        var selfNegative = shareAbs.isNegative;
+        shareAbs = shareAbs.result.csub(offset);
+
+        var otherNegative = cst < 0;
+        var cstAbs = Math.abs(cst);
+
+        // This is the result assuming both share and o are non-negative
+        var result = shareAbs.legacy.cdiv(cstAbs, op_id+":c/").cadd(offset);
+
+        // o is non-negative
+        if(!otherNegative) {
+          // only need to correct for if share is negative
+          result = result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
+        }
+        // o is negative
+        else {
+          // correct for o
+          result = result.cmult(-1);
+          // if share is negative, result becomes positive again
+          result = result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
+        }
+
+        // Round to zero
+        if(floor_down === false) {
+          return result;
+        }
+        // Round down
+        else {
+          var need_round = result.smult(share, op_id+":floor:smult").cneq(cst, op_id+":floor:cneq");
+          var xorNegative = selfNegative.cxor_bit(otherNegative ? 1 : 0);
+          return result.sadd(need_round.smult(xorNegative, op_id+":floor:&").cmult(-1));
+        }
+      };
+      share.sdiv = function(o, l, op_id, floor_down) {
+        if (op_id == null) {
+          op_id = share.jiff.counters.gen_op_id('/', share.holders);
+        }
+
+        var shareAbs = share.abs(op_id+":abs1", true);
+        var selfNegative = shareAbs.isNegative;
+        shareAbs = shareAbs.result.csub(offset);
+
+        var otherAbs = o.abs(op_id+":abs2", true)
+        var otherNegative = otherAbs.isNegative;
+        otherAbs = otherAbs.result.csub(offset);
+
+        // This is the result assuming both share and o are non-negative
+        var result = shareAbs.legacy.sdiv(otherAbs, l, op_id+":/").cadd(offset);
+
+        // correct for self
+        result = result.smult(selfNegative.cmult(-2).cadd(1), op_id+":cor1");
+        // correct for o
+        result = result.smult(otherNegative.cmult(-2).cadd(1), op_id+":cor2");
+        // correct for both
+        var bothNegative = selfNegative.smult(otherNegative, op_id+":&");
+        //result = result.smult(bothNegative.cmult(-2).cadd(1), op_id+":cor3");
+        return result;
+        /*
+        // Round to zero
+        if(floor_down === false) {
+          return result;
+        }
+        // Round down
+        else {
+          var need_round = result.smult(share, op_id+":floor:smult").sneq(o, op_id+":floor:cneq");
+          var xorNegative = selfNegative.sadd(otherNegative).ssub(bothNegative.cmult(2));
+          return result.sadd(need_round.smult(xorNegative, op_id+":floor:&").cmult(-1));
+        }*/
       };
 
       // secret boolean operations
@@ -89,6 +196,9 @@
         share[key] = (function(key, i) {
           return function() {
             if (i > 5 && i < 12) {
+              if (!(share.isConstant(arguments[0]))) {
+                throw 'Parameter should be a number (' + key + ')';
+              }
               arguments[0] = arguments[0] + offset;
             }
             var result = share.legacy[key].apply(share, arguments);
@@ -101,6 +211,20 @@
       share.not = function() {
         return share.cmult(-1).cadd(1);
       }
+
+      // absolute value
+      share.abs = function(op_id, return_intermediate) {
+        if (op_id == null) {
+          op_id = share.jiff.counters.gen_op_id('abs', share.holders);
+        }
+
+        var isNegative = share.legacy.clt(offset, op_id+":clt"); // 0 or 1, no offset
+        var correction = share.csub(offset).legacy.cmult(2);
+        var result = share.legacy.ssub(correction.legacy.smult(isNegative, op_id+":smult"));
+
+        if(return_intermediate === true) return { "result": result, "isNegative": isNegative.cadd(offset) };
+        else return result;
+      };
 
       return share;
     }

--- a/tests/mocha-negative-number/comparison.js
+++ b/tests/mocha-negative-number/comparison.js
@@ -75,9 +75,9 @@ function run_test(computation_id, operation, callback) {
   options.onConnect = function() { if(++counter == 3) test(callback, operation); };
   options.onError = function(error) { console.log(error); has_failed = true; };
 
-  var jiff_instance1 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
-  var jiff_instance2 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
-  var jiff_instance3 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
+  var jiff_instance1 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
+  var jiff_instance2 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
+  var jiff_instance3 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
   jiff_instances = [jiff_instance1, jiff_instance2, jiff_instance3];
   jiff_instance1.connect();
   jiff_instance2.connect();

--- a/tests/mocha-negative-number/constant_arithmetic_op.js
+++ b/tests/mocha-negative-number/constant_arithmetic_op.js
@@ -35,10 +35,12 @@ var operations = {
     return operand1.cxor_bit(operand2);
   },
   "/" : function (operand1, operand2) {
-    return Math.floor(operand1 / operand2);
+    var res = operand1 / operand2;
+    if(res < 0) return Math.ceil(res);
+    else return Math.floor(res);
   },
   "div_cst" : function (operand1, operand2) {
-    return operand1.cdiv(operand2);
+    return operand1.cdiv(operand2, null, false); // Round to zero
   },
 };
 
@@ -80,9 +82,9 @@ function run_test(computation_id, operation, callback) {
   options.onConnect = function() { if(++counter == 3) test(callback, operation); };
   options.onError = function(error) { console.log(error); has_failed = true; };
 
-  var jiff_instance1 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
-  var jiff_instance2 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
-  var jiff_instance3 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
+  var jiff_instance1 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
+  var jiff_instance2 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
+  var jiff_instance3 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
   jiff_instances = [jiff_instance1, jiff_instance2, jiff_instance3];
   jiff_instance1.connect();
   jiff_instance2.connect();
@@ -98,7 +100,7 @@ function test(callback, mpc_operator) {
 
   // Run every test and accumelate all the promises
   var promises = [];
-  var length = mpc_operator == "div_cst" ? 5 : tests.length;
+  var length = mpc_operator == "div_cst" ? 10 : tests.length;
   for(var i = 0; i < length; i++) {
     for (var j = 0; j < jiff_instances.length; j++) {
       var promise = single_test(i, jiff_instances[j], mpc_operator, open_operator);

--- a/tests/mocha-negative-number/constant_comparison.js
+++ b/tests/mocha-negative-number/constant_comparison.js
@@ -76,9 +76,9 @@ function run_test(computation_id, operation, callback) {
   options.onConnect = function() { if(++counter == 3) test(callback, operation); };
   options.onError = function(error) { console.log(error); has_failed = true; };
 
-  var jiff_instance1 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
-  var jiff_instance2 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
-  var jiff_instance3 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
+  var jiff_instance1 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
+  var jiff_instance2 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
+  var jiff_instance3 = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
   jiff_instances = [jiff_instance1, jiff_instance2, jiff_instance3];
   jiff_instance1.connect();
   jiff_instance2.connect();

--- a/tests/mocha-negative-number/index.js
+++ b/tests/mocha-negative-number/index.js
@@ -31,6 +31,7 @@ describe("MPC Operations", function() {
 
 
   describe("Arithmetic Operations", function() {
+  /*
     //+
     it("Addition", function (done) {
         arithmetic_op.run_test(i++, "add", callback(done));
@@ -47,10 +48,11 @@ describe("MPC Operations", function() {
     it("Bitwise XOR", function(done) {
       arithmetic_op.run_test(i++, "xor", callback(done));
     });
+    */
     // /
-    //it("Integer Divison", function(done) {
-    //  arithmetic_op.run_test(i++, "div", callback(done));
-    //});
+    it("Integer Divison", function(done) {
+      arithmetic_op.run_test(i++, "div", callback(done));
+    });
   });
 
   describe("Constant Arithmetic Operations", function() {
@@ -71,9 +73,9 @@ describe("MPC Operations", function() {
       constant_arithmetic_op.run_test(i++, "xor_cst", callback(done));
     });
     // /
-    //it("Constant Integer Divison", function(done) {
-    //  constant_arithmetic_op.run_test(i++, "div_cst", callback(done));
-    //});
+    it("Constant Integer Divison", function(done) {
+      constant_arithmetic_op.run_test(i++, "div_cst", callback(done));
+    });
   });
 
   

--- a/tests/mocha-negative-number/index.js
+++ b/tests/mocha-negative-number/index.js
@@ -31,7 +31,6 @@ describe("MPC Operations", function() {
 
 
   describe("Arithmetic Operations", function() {
-  /*
     //+
     it("Addition", function (done) {
         arithmetic_op.run_test(i++, "add", callback(done));
@@ -48,7 +47,6 @@ describe("MPC Operations", function() {
     it("Bitwise XOR", function(done) {
       arithmetic_op.run_test(i++, "xor", callback(done));
     });
-    */
     // /
     it("Integer Divison", function(done) {
       arithmetic_op.run_test(i++, "div", callback(done));

--- a/tests/mocha-negative-number/server.js
+++ b/tests/mocha-negative-number/server.js
@@ -15,6 +15,6 @@ jiff_instance.compute('1', function(computation_instance) {
 app.use("/demos", express.static("demos"));
 app.use("/lib", express.static("lib"));
 app.use("/lib/ext", express.static("lib/ext"));
-http.listen(3000, function() {
-  console.log('listening on *:3000');
+http.listen(3003, function() {
+  console.log('listening on *:3003');
 });

--- a/tests/mocha-negative-number/share.js
+++ b/tests/mocha-negative-number/share.js
@@ -51,7 +51,7 @@ function run_test(computation_id, callback) {
   options.onError = function(error) { console.log(error); has_failed = true; };
 
   for(var i = 0; i < parties; i++) {
-    var jiff_instance = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3000", computation_id, options));
+    var jiff_instance = jiffNegNumber.make_jiff(jiff.make_jiff("http://localhost:3003", computation_id, options));
     jiff_instances.push(jiff_instance);
     jiff_instance.connect();
   }


### PR DESCRIPTION
Negative Number Extension using an offset to split the range [0 ... Zp) into [0 ... Zp/2) for negatives and [ Zp/2 ... Zp) for positive (all floored, all upper-bound exclusive).

Supports all regular jiff primitives, plus an absolute value primitive: share.ab([<op_id>]). With test cases.