### PR TITLE
Replace jQuery Deferred for client with native Promise wrapper

### DIFF
--- a/lib/jiff-client.js
+++ b/lib/jiff-client.js
@@ -232,10 +232,10 @@
         // check if a deferred is set up (maybe the message was previously received)
         if (jiff.deferreds[share_id][p_id] == null) {
           // not ready, setup a deferred
-          jiff.deferreds[share_id][p_id] = $.Deferred();
+          jiff.deferreds[share_id][p_id] = new Deferred();
         }
 
-        var promise = jiff.deferreds[share_id][p_id].promise();
+        var promise = jiff.deferreds[share_id][p_id].promise;
 
         // destroy deferred when done
         (function (promise, p_id) { // p_id is modified in a for loop, must do this to avoid scoping issues.
@@ -327,7 +327,7 @@
     }
     if (jiff.deferreds[op_id][sender_id] == null) {
       // Share is received before deferred was setup, store it.
-      jiff.deferreds[op_id][sender_id] = $.Deferred();
+      jiff.deferreds[op_id][sender_id] = new Deferred();
     }
 
     // Deferred is already setup, resolve it.
@@ -411,8 +411,8 @@
     // Party is a receiver
     if (parties.indexOf(jiff.id) > -1) {
       var shares = []; // this will store received shares
-      var final_deferred = $.Deferred(); // will be resolved when the final value is reconstructed
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred(); // will be resolved when the final value is reconstructed
+      var final_promise = final_deferred.promise;
       for (i = 0; i < share.holders.length; i++) {
         var p_id = share.holders[i];
 
@@ -421,11 +421,11 @@
           jiff.deferreds[op_ids[jiff.id]] = {};
         }
         if (jiff.deferreds[op_ids[jiff.id]][p_id] == null) {
-          jiff.deferreds[op_ids[jiff.id]][p_id] = $.Deferred();
+          jiff.deferreds[op_ids[jiff.id]][p_id] = new Deferred();
         }
 
         // Clean up deferred when fulfilled
-        var promise = jiff.deferreds[op_ids[jiff.id]][p_id].promise();
+        var promise = jiff.deferreds[op_ids[jiff.id]][p_id].promise;
 
         // destroy deferred when done
         (function (promise, p_id) { // p_id is modified in a for loop, must do this to avoid scoping issues.
@@ -516,7 +516,7 @@
       jiff.deferreds[op_id] = {};
     }
     if (jiff.deferreds[op_id][sender_id] == null) {
-      jiff.deferreds[op_id][sender_id] = $.Deferred();
+      jiff.deferreds[op_id][sender_id] = new Deferred();
     }
 
     jiff.deferreds[op_id][sender_id].resolve({value: share, sender_id: sender_id, Zp: Zp});
@@ -600,9 +600,9 @@
     msg = JSON.stringify(msg);
 
     // Setup deferred to handle receiving the triplets later.
-    var a_deferred = $.Deferred();
-    var b_deferred = $.Deferred();
-    var c_deferred = $.Deferred();
+    var a_deferred = new Deferred();
+    var b_deferred = new Deferred();
+    var c_deferred = new Deferred();
     jiff.deferreds[triplet_id] = {a: a_deferred, b: b_deferred, c: c_deferred};
 
     // send a request to the server.
@@ -613,9 +613,9 @@
       jiff.socket.safe_emit('triplet', JSON.stringify(cipher));
     }
 
-    var a_share = jiff.secret_share(jiff, false, a_deferred.promise(), undefined, receivers_list, threshold, Zp, triplet_id + ':a');
-    var b_share = jiff.secret_share(jiff, false, b_deferred.promise(), undefined, receivers_list, threshold, Zp, triplet_id + ':b');
-    var c_share = jiff.secret_share(jiff, false, c_deferred.promise(), undefined, receivers_list, threshold, Zp, triplet_id + ':c');
+    var a_share = jiff.secret_share(jiff, false, a_deferred.promise, undefined, receivers_list, threshold, Zp, triplet_id + ':a');
+    var b_share = jiff.secret_share(jiff, false, b_deferred.promise, undefined, receivers_list, threshold, Zp, triplet_id + ':b');
+    var c_share = jiff.secret_share(jiff, false, c_deferred.promise, undefined, receivers_list, threshold, Zp, triplet_id + ':c');
     return [a_share, b_share, c_share];
   }
 
@@ -742,9 +742,9 @@
     // Setup deferreds to handle receiving the triplets later.
     var shares = [];
     for (i = 0; i < options.count; i++) {
-      var deferred = $.Deferred();
+      var deferred = new Deferred();
       jiff.deferreds[number_id + ':' + i] = deferred;
-      shares[i] = jiff.secret_share(jiff, false, deferred.promise(), undefined, receivers_list, threshold, Zp, number_id + ':' + i);
+      shares[i] = jiff.secret_share(jiff, false, deferred.promise, undefined, receivers_list, threshold, Zp, number_id + ':' + i);
     }
 
     // Send a request to the server.
@@ -845,8 +845,8 @@
     }
 
     // wrap around result of share_array
-    var share_array_deferred = $.Deferred();
-    var share_array_promise = share_array_deferred.promise();
+    var share_array_deferred = new Deferred();
+    var share_array_promise = share_array_deferred.promise;
 
     // figure out lengths by having each party emit their length publicly
     if (lengths == null) {
@@ -1000,8 +1000,8 @@
     }
 
     // wrap around result of share_array
-    var lengths_deferred = $.Deferred();
-    var lengths_promise = lengths_deferred.promise();
+    var lengths_deferred = new Deferred();
+    var lengths_promise = lengths_deferred.promise;
 
     // figure out lengths by having each party emit their length publicly
     if (lengths == null) {
@@ -1043,8 +1043,8 @@
     }
 
     // Final results
-    var share_array_deferred = $.Deferred();
-    var share_array_promise = share_array_deferred.promise();
+    var share_array_deferred = new Deferred();
+    var share_array_promise = share_array_deferred.promise;
 
     // lengths are now set, start sharing
     lengths_promise.then(function (lengths) {
@@ -1218,6 +1218,30 @@
     }
   }
 
+  function Deferred() {
+    // Polyfill for jQuery Deferred
+    // From https://developer.mozilla.org/en-US/docs/Mozilla/JavaScript_code_modules/Promise.jsm/Deferred
+    this.resolve = null;
+
+    /* A method to reject the assocaited Promise with the value passed.
+     * If the promise is already settled it does nothing.
+     *
+     * @param {anything} reason: The reason for the rejection of the Promise.
+     * Generally its an Error object. If however a Promise is passed, then the Promise
+     * itself will be the reason for rejection no matter the state of the Promise.
+     */
+    this.reject = null;
+
+    /* A newly created Promise object.
+     * Initially in pending state.
+     */
+    this.promise = new Promise(function(resolve, reject) {
+      this.resolve = resolve;
+      this.reject = reject;
+    }.bind(this));
+    Object.freeze(this);
+  }
+
   /**
    * Secret share objects: provides API to perform operations on shares securly, wrap promises
    * and communication primitives to ensure operations are executed when shares are available (asynchronously)
@@ -1288,7 +1312,6 @@
         return v1 === v2;
       }
     };
-
 
     var self = {};
 
@@ -1919,8 +1942,8 @@
         op_id = self.jiff.counters.gen_op_id('*', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, max(self.threshold, o.threshold), self.Zp, 'share:' + op_id);
 
       // Get shares of triplets.
@@ -1997,8 +2020,8 @@
         op_id = self.jiff.counters.gen_op_id('bgw*', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, max(self.threshold, o.threshold), self.Zp, 'share:' + op_id);
 
       Promise.all([self.promise, o.promise]).then(
@@ -2029,8 +2052,8 @@
         op_id = self.jiff.counters.gen_op_id('threshold:', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, threshold, self.Zp, 'share:' + op_id);
 
       var ready_threshold = function () {
@@ -2269,8 +2292,8 @@
         op_id = self.jiff.counters.gen_op_id('<', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, max(self.threshold, o.threshold), self.Zp, 'share:' + op_id);
 
       var w = self.ilt_halfprime(op_id + ':halfprime:1');
@@ -2340,8 +2363,8 @@
         op_id = self.jiff.counters.gen_op_id('c>', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, self.threshold, self.Zp, 'share:' + op_id);
 
       var w = share_helpers['<'](cst, share_helpers['/'](self.Zp, 2)) ? 1 : 0;
@@ -2408,8 +2431,8 @@
         op_id = self.jiff.counters.gen_op_id('c<', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, self.threshold, self.Zp, 'share:' + op_id);
 
       var w = self.ilt_halfprime(op_id + ':halfprime:1');
@@ -2574,8 +2597,8 @@
       }
 
       // Store the result
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, max(self.threshold, o.threshold), self.Zp, 'share:' + op_id);
 
       var q = self.jiff.server_generate_and_share({number: 0}, self.holders, max(self.threshold, o.threshold), self.Zp, op_id + ':number')[0];
@@ -2642,8 +2665,8 @@
       }
 
       // Allocate share for result to which the answer will be resolved once available
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, self.threshold, self.Zp, 'share:' + op_id);
 
       var ZpOVERc = share_helpers['floor/'](self.Zp, cst);
@@ -2733,8 +2756,8 @@
         op_id = self.jiff.counters.gen_op_id('lt_hp', self.holders);
       }
 
-      var final_deferred = $.Deferred();
-      var final_promise = final_deferred.promise();
+      var final_deferred = new Deferred();
+      var final_promise = final_deferred.promise;
       var result = self.jiff.secret_share(self.jiff, false, final_promise, undefined, self.holders, self.threshold, self.Zp, 'share:' + op_id);
 
       // if 2*self is even, then self is less than half prime, otherwise self is greater or equal to half prime
@@ -3075,8 +3098,8 @@
               callback();
             }
           } else {
-            socket.empty_deferred = $.Deferred();
-            socket.empty_deferred.promise().then(ready);
+            socket.empty_deferred = new Deferred();
+            socket.empty_deferred.promise.then(ready);
           }
         }());
       };


### PR DESCRIPTION
Keeps API very similar for now, but can be changed in the future if we want to get rid of the extra object instantiation