### PR TITLE
Fix while condition in AKS primality test (previously it would always…

### DIFF
--- a/lib/ext/jiff-client-bignumber.js
+++ b/lib/ext/jiff-client-bignumber.js
@@ -102,7 +102,7 @@
     var i = new BigNumber_(5);
     var n = new BigNumber_(2);
     var six6 = new BigNumber_(6);
-    while (i.times(i).lte(n)) {
+    while (i.times(i).lte(p)) {
       if (p.mod(i).eq(0)) {
         return false;
       }

--- a/lib/jiff-client.js
+++ b/lib/jiff-client.js
@@ -68,7 +68,7 @@
 
     var i = 5;
     var n = 2;
-    while (i * i <= n) {
+    while (i * i <= p) {
       if (p % i === 0) {
         return false;
       }


### PR DESCRIPTION
… fail, skipping the while loop completely and returning false positives)

Co-authored-by: Peter <pflock@bu.edu>
Co-authored-by: Ashni <sashni@bu.edu>