### PR TITLE
Free disconnect (for running demos repeatedly)

### DIFF
--- a/demos/array-binary-search/party.js
+++ b/demos/array-binary-search/party.js
@@ -44,7 +44,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/array-bubble-sort/party.js
+++ b/demos/array-bubble-sort/party.js
@@ -35,7 +35,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/array-concat/party.js
+++ b/demos/array-concat/party.js
@@ -34,7 +34,7 @@ options.onConnect = function (jiff_instance) {
   var promise = mpc.compute(input);
   promise.then(function (results) {
     console.log(results);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/array-merge-sort/party.js
+++ b/demos/array-merge-sort/party.js
@@ -45,7 +45,7 @@ options.onConnect = function (jiff_instance) {
   var promise = mpc.compute(input);
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/array-shell-sort/party.js
+++ b/demos/array-shell-sort/party.js
@@ -35,7 +35,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/array-substring/party.js
+++ b/demos/array-substring/party.js
@@ -41,10 +41,9 @@ options.onConnect = function (jiff_instance) {
       }
     }
 
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 
 // Connect
 mpc.connect('http://localhost:8080', computation_id, options);
-

--- a/demos/fixednegative-min/party.js
+++ b/demos/fixednegative-min/party.js
@@ -40,7 +40,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v.toString(10));
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/fixedpoint-sum/party.js
+++ b/demos/fixedpoint-sum/party.js
@@ -41,7 +41,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v.toString(10));
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/image-comparison/party.js
+++ b/demos/image-comparison/party.js
@@ -35,7 +35,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/pca/party.js
+++ b/demos/pca/party.js
@@ -46,7 +46,7 @@ options.onConnect = function (jiff_instance) {
   promise.then(function (v) {
     console.log('the result of PCA is:');
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/standard-deviation/party.js
+++ b/demos/standard-deviation/party.js
@@ -41,7 +41,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v.toString(10));
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/sum/party.js
+++ b/demos/sum/party.js
@@ -35,7 +35,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/template/party.js
+++ b/demos/template/party.js
@@ -35,7 +35,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/the-valentine-question/party.js
+++ b/demos/the-valentine-question/party.js
@@ -35,7 +35,7 @@ options.onConnect = function (jiff_instance) {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 };
 

--- a/demos/threshold/party.js
+++ b/demos/threshold/party.js
@@ -40,6 +40,6 @@ jiff_instance.wait_for(upper_parties, function () {
 
   promise.then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   });
 });

--- a/demos/vote-check/party.js
+++ b/demos/vote-check/party.js
@@ -34,7 +34,7 @@ var options = {party_count: party_count, party_id: party_id, Zp: 31 };
 options.onConnect = function (jiff_instance) {
   mpc.compute(input).then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   }, function (e) {
     console.log(e);
   });

--- a/demos/vote/party.js
+++ b/demos/vote/party.js
@@ -34,7 +34,7 @@ var options = {party_count: party_count, party_id: party_id};
 options.onConnect = function (jiff_instance) {
   mpc.compute(input).then(function (v) {
     console.log(v);
-    jiff_instance.disconnect(true);
+    jiff_instance.disconnect(false, true);
   }, function (e) {
     console.log(e);
   });


### PR DESCRIPTION
- Small change to free up ids after everything has finished computing, so that demos can be run repeatedly without having to restart the server each time.

Some of the demos already do this, but the template and the majority of demos don't.