### PR TITLE
Set jiff.sodium_ to false as opposed to null when options.sodium == f…

### DIFF
--- a/demos/fixedpoint-sum/mpc.js
+++ b/demos/fixedpoint-sum/mpc.js
@@ -8,6 +8,7 @@
     var opt = Object.assign({}, options);
     opt.warn = false;
     opt.crypto_provider = true;
+    opt.sodium = false;
 
     // Added options goes here
     if (node) {

--- a/demos/fixedpoint-sum/server.js
+++ b/demos/fixedpoint-sum/server.js
@@ -3,7 +3,7 @@ var express = require('express');
 var app = express();
 var http = require('http').Server(app);
 var JIFFServer = require('../../lib/jiff-server');
-var base_instance = new JIFFServer(http, { logs:true });
+var base_instance = new JIFFServer(http, { logs: true, sodium: false });
 
 var jiffBigNumberServer = require('../../lib/ext/jiff-server-bignumber');
 base_instance.apply_extension(jiffBigNumberServer);

--- a/demos/mpc-as-a-service/client-mpc.js
+++ b/demos/mpc-as-a-service/client-mpc.js
@@ -2,6 +2,8 @@
   if (node) {
     // eslint-disable-next-line no-undef
     JIFFClient = require('../../lib/jiff-client.js');
+    // eslint-disable-next-line no-undef
+    jiff_restAPI = require('../../lib/ext/jiff-client-restful.js');
   }
 
   var __jiff_instance, config;
@@ -12,9 +14,13 @@
     opt['crypto_provider'] = config.preprocessing === false;
     opt['initialization'] = { role: 'input' };
     opt['party_count'] = config.party_count;
+    opt['autoConnect'] = false;
 
     // eslint-disable-next-line no-undef
     __jiff_instance = new JIFFClient(hostname, computation_id, opt);
+    // eslint-disable-next-line no-undef
+    __jiff_instance.apply_extension(jiff_restAPI);
+    __jiff_instance.connect();
     return __jiff_instance;
   };
   exports.compute = function (input, jiff_instance_) {

--- a/demos/mpc-as-a-service/client.html
+++ b/demos/mpc-as-a-service/client.html
@@ -12,6 +12,7 @@
 
   <script src="https://code.jquery.com/jquery-1.11.1.js"></script>
   <script src="/dist/jiff-client.js"></script>
+  <script src="/lib/ext/jiff-client-restful.js"></script>
 
   <!-- Contains UI Handlers and Input Checks -->
   <script type="text/javascript" src="./client.js"></script>

--- a/demos/mpc-as-a-service/server.js
+++ b/demos/mpc-as-a-service/server.js
@@ -14,6 +14,11 @@ var app = express();
 var http = require('http').Server(app);
 var path = require('path');
 
+// body parser to handle json data
+var bodyParser  = require('body-parser');
+app.use(bodyParser.urlencoded({ extended: true }));
+app.use(bodyParser.json());
+
 // Read configuration
 var config = './config.json';
 if (process.argv[2] != null) {
@@ -62,7 +67,9 @@ var options = {
 
 // Create the server
 var JIFFServer = require('../../lib/jiff-server');
-new JIFFServer(http, options);
+var jiffRestAPIServer = require('../../lib/ext/jiff-server-restful.js');
+var jiffServer = new JIFFServer(http, options);
+jiffServer.apply_extension(jiffRestAPIServer, {app: app});
 
 // Serve static files.
 app.get('/config.js', function (req, res) {
@@ -73,6 +80,7 @@ app.get('/config.js', function (req, res) {
 
 app.use('/demos', express.static(path.join(__dirname, '..', '..', 'demos')));
 app.use('/dist', express.static(path.join(__dirname, '..', '..', 'dist')));
+app.use('/lib/ext', express.static(path.join(__dirname, '..', '..', 'lib', 'ext')));
 http.listen(8080, function () {
   console.log('listening on *:8080');
 });

--- a/demos/mpc-as-a-service/tests/test.js
+++ b/demos/mpc-as-a-service/tests/test.js
@@ -15,7 +15,7 @@ describe('MPC-as-a-service', function () {
     var output = 0;
     var promises = [];
     for (var i = 0; i < input_parties_count; i++) {
-      var jiffClient = clientMPC.connect('http://localhost:8080', 'test', {}, config);
+      var jiffClient = clientMPC.connect('http://localhost:8080/', 'test', {}, config);
 
       // generate input
       var input = Math.floor(Math.random() * jiffClient.Zp);

--- a/demos/vote-check/mpc.js
+++ b/demos/vote-check/mpc.js
@@ -9,6 +9,7 @@
     // Added options goes here
     opt.Zp = 13;
     opt.crypto_provider = true;
+    opt.sodium = false;
 
     if (node) {
       // eslint-disable-next-line no-undef

--- a/demos/vote-check/server.js
+++ b/demos/vote-check/server.js
@@ -3,7 +3,7 @@ var express = require('express');
 var app = express();
 var http = require('http').Server(app);
 var JIFFServer = require('../../lib/jiff-server');
-new JIFFServer(http, { logs:true });
+new JIFFServer(http, { logs: true, sodium: false });
 
 // Serve static files.
 app.use('/demos', express.static(path.join(__dirname, '..', '..', 'demos')));

--- a/lib/client/arch/hooks.js
+++ b/lib/client/arch/hooks.js
@@ -47,7 +47,7 @@ Hooks.prototype.reconstructShare = shamir_open.jiff_lagrange;
 
 // Crypto hooks
 Hooks.prototype.encryptSign = function (jiffClient, message) {
-  if (jiffClient.options.sodium !== false) {
+  if (jiffClient.sodium_ !== false) {
     return crypto.encrypt_and_sign.apply(null, arguments);
   } else {
     return message;
@@ -55,7 +55,7 @@ Hooks.prototype.encryptSign = function (jiffClient, message) {
 };
 
 Hooks.prototype.decryptSign = function (jiffClient, cipher) {
-  if (jiffClient.options.sodium !== false) {
+  if (jiffClient.sodium_ !== false) {
     return crypto.decrypt_and_sign.apply(null, arguments);
   } else {
     return cipher;
@@ -63,7 +63,7 @@ Hooks.prototype.decryptSign = function (jiffClient, cipher) {
 };
 
 Hooks.prototype.generateKeyPair = function (jiffClient) {
-  if (jiffClient.options.sodium !== false) {
+  if (jiffClient.sodium_ !== false) {
     var key = jiffClient.sodium_.crypto_box_keypair(); // this party's public and secret key
     return { public_key: key.publicKey, secret_key: key.privateKey }
   } else {
@@ -72,7 +72,7 @@ Hooks.prototype.generateKeyPair = function (jiffClient) {
 };
 
 Hooks.prototype.parseKey = function (jiffClient, keyString) {
-  if (jiffClient.options.sodium !== false) {
+  if (jiffClient.sodium_ !== false) {
     return new Uint8Array(JSON.parse(keyString));
   } else {
     return '';
@@ -80,7 +80,7 @@ Hooks.prototype.parseKey = function (jiffClient, keyString) {
 };
 
 Hooks.prototype.dumpKey = function (jiffClient, key) {
-  if (jiffClient.options.sodium !== false) {
+  if (jiffClient.sodium_ !== false) {
     return '[' + key.toString() + ']';
   } else {
     return '';

--- a/lib/ext/jiff-client-restful.js
+++ b/lib/ext/jiff-client-restful.js
@@ -291,7 +291,7 @@
         jiff.flushInterval = options.flushInterval !== 0 ? setInterval(jiff.restFlush, options.flushInterval) : null;
       };
 
-      if (jiff.sodium_ == null) {
+      if (jiff.sodium_ === false) {
         setup();
       } else {
         jiff.sodium_.ready.then(setup);

--- a/lib/jiff-client.js
+++ b/lib/jiff-client.js
@@ -196,7 +196,7 @@ function JIFFClient(hostname, computation_id, options) {
    * @see {@link https://www.npmjs.com/package/libsodium-wrappers}
    * @type {?sodium}
    */
-  this.sodium_ = options.sodium !== false ? sodium : null;
+  this.sodium_ = options.sodium !== false ? sodium : false;
 
   /**
    * A map from party id to public key. Where key is the party id (number), and

--- a/lib/jiff-client.js
+++ b/lib/jiff-client.js
@@ -193,7 +193,7 @@ function JIFFClient(hostname, computation_id, options) {
 
   /**
    * sodium wrappers either imported via require (if in nodejs) or from the bundle (in the browser).
-   * This will be undefined if options.sodium is false.
+   * This will be false if options.sodium is false.
    * @see {@link https://www.npmjs.com/package/libsodium-wrappers}
    * @type {?sodium}
    */

--- a/lib/jiff-client.js
+++ b/lib/jiff-client.js
@@ -87,6 +87,7 @@ var preprocessingDaemon = require('./client/preprocessing/daemon.js');
    "safemod": boolean (whether or not to check if provided Zp is prime, may be slow for big primes, defaults to false),
    "crypto_provider": a boolean that flags whether to get beaver triplets and other preprocessing entities from the server (defaults to false),
    "socketOptions": an object, passed directly to socket.io constructor,
+   "sodium": boolean, if false messages between clients will not be encrypted (useful for debugging),
    "maxInitializationRetries": how many consecutive times to retry to initialize with the server if initialization fails, defaults to 2,
    "preprocessingBatchSize": how many base level preprocessing tasks to execute in parallel.
  }


### PR DESCRIPTION
…alse. This avoids an error in jiffClient.connect() where a check is performed to wait for sodium if necessary
resolves issue #191 
### Alternative:
could change line 449 in lib/jiff-client.js to not check for strict equality with false.