### PR TITLE
import sodium only if needed

### DIFF
--- a/lib/jiff-client.js
+++ b/lib/jiff-client.js
@@ -24,9 +24,6 @@
  * @alias jiff-client
  */
 
-// browserify bundles this into our code bundle
-var sodium = require('libsodium-wrappers');
-
 // utils and helpers
 var constants = require('./client/util/constants.js');
 var helpers = require('./client/util/helpers.js');
@@ -199,7 +196,7 @@ function JIFFClient(hostname, computation_id, options) {
    * @see {@link https://www.npmjs.com/package/libsodium-wrappers}
    * @type {?sodium}
    */
-  this.sodium_ = options.sodium !== false ? sodium : false;
+  this.sodium_ = options.sodium !== false ? require("libsodium-wrappers") : false;
 
   /**
    * A map from party id to public key. Where key is the party id (number), and


### PR DESCRIPTION
I face a problem that node.js crashes if libsodium is imported ()

In order to be able to run jiff anyway, I changed the code such that libsodium is only imported if it is actually used.

Tested on node.js, not in the browser.