### PR TITLE
fix an issue with ref comparison instead of value

### DIFF
--- a/lib/client/protocols/shamir/open.js
+++ b/lib/client/protocols/shamir/open.js
@@ -45,7 +45,7 @@ module.exports = {
     }
 
     // Default values
-    if (parties == null || parties === []) {
+    if (parties == null || parties.length === 0) {
       parties = [];
       for (i = 1; i <= jiff.party_count; i++) {
         parties.push(i);


### PR DESCRIPTION
Mostly pointed out by linter, but "This condition will always return 'false' since JavaScript compares objects by reference, not value". Added in a quick fix with `parties.length === 0` - since the value and types both can correctly be compared as opposed to `parties === []` where types are (likely) different thus a forever-false situation.